### PR TITLE
招待メールにログイン画面URLを追加

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -42,6 +42,8 @@ api/
 | `DEFAULT_ORG_NAME` | seed 組織名 |
 | `DEFAULT_ORG_SLUG` | seed 組織 slug |
 | `OWNER_EMAILS` | `OWNER` 扱いにする email の CSV |
+| `INVITE_FROM_EMAIL` | 招待メール送信元メールアドレス（デフォルト `no-reply@stepbycode.work`） |
+| `INVITE_LOGIN_URL` | 招待メールに記載するログイン画面 URL（デフォルト `https://backstage.stepbycode.work/login`） |
 | `CORS_ALLOWED_ORIGINS` | 追加で許可する Origin の CSV。`https://backatage.stepbycode.work` のような完全一致と `https://*.stepbycode.work` / `*.vercel.app` のようなワイルドカードを受け付ける |
 | `PORT` | サーバーポート（デフォルト `9999`、Coolify では Internal Port も同じ値に揃える） |
 

--- a/api/internal/app/http.go
+++ b/api/internal/app/http.go
@@ -131,6 +131,7 @@ func NewHTTPHandler(ctx context.Context) (http.Handler, config.Config, *slog.Log
 		FirebaseAuth: userCreator,
 		ResendAPIKey: cfg.ResendAPIKey,
 		FromEmail:    cfg.InviteFromEmail,
+		LoginURL:     cfg.InviteLoginURL,
 		Webhook:      webhook,
 		Logger:       logger,
 	})

--- a/api/internal/config/config.go
+++ b/api/internal/config/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	Port                    string
 	ResendAPIKey            string
 	InviteFromEmail         string
+	InviteLoginURL          string
 	CronSecret              string
 	CORSAllowedOrigins      []string
 }
@@ -31,6 +32,7 @@ func Load() (Config, error) {
 		Port:                    defaultValue(strings.TrimSpace(os.Getenv("PORT")), "9999"),
 		ResendAPIKey:            strings.TrimSpace(os.Getenv("RESEND_API_KEY")),
 		InviteFromEmail:         defaultValue(strings.TrimSpace(os.Getenv("INVITE_FROM_EMAIL")), "no-reply@stepbycode.work"),
+		InviteLoginURL:          defaultValue(strings.TrimSpace(os.Getenv("INVITE_LOGIN_URL")), "https://backstage.stepbycode.work/login"),
 		CronSecret:              strings.TrimSpace(os.Getenv("CRON_SECRET")),
 		CORSAllowedOrigins:      parseCSV(strings.TrimSpace(os.Getenv("CORS_ALLOWED_ORIGINS"))),
 	}

--- a/api/internal/simpleapi/invite.go
+++ b/api/internal/simpleapi/invite.go
@@ -27,6 +27,7 @@ type InviteDeps struct {
 	FirebaseAuth FirebaseUserCreator
 	ResendAPIKey string
 	FromEmail    string
+	LoginURL     string
 	Webhook      *discord.WebhookClient
 	Logger       *slog.Logger
 }
@@ -126,7 +127,7 @@ func inviteHandler(deps InviteDeps) echo.HandlerFunc {
 			})
 		}
 
-		if err := sendInviteEmail(ctx, deps.ResendAPIKey, deps.FromEmail, email, password); err != nil {
+		if err := sendInviteEmail(ctx, deps.ResendAPIKey, deps.FromEmail, deps.LoginURL, email, password); err != nil {
 			deps.Logger.Error("failed to send invite email", slog.Any("error", err), slog.String("email", email))
 			rollbackInvite(ctx, deps, uid)
 			return c.JSON(http.StatusInternalServerError, ErrorResponse{
@@ -299,7 +300,12 @@ func rollbackInvite(ctx context.Context, deps InviteDeps, uid string) error {
 	return firstErr
 }
 
-func sendInviteEmail(ctx context.Context, apiKey, fromEmail, toEmail, password string) error {
+func sendInviteEmail(ctx context.Context, apiKey, fromEmail, loginURL, toEmail, password string) error {
+	loginURL = strings.TrimSpace(loginURL)
+	if loginURL == "" {
+		loginURL = "https://backstage.stepbycode.work/login"
+	}
+
 	htmlBody := fmt.Sprintf(`
 <div style="font-family: sans-serif; max-width: 480px; margin: 0 auto; padding: 2rem;">
   <h2 style="color: #df6900;">Backstage へようこそ</h2>
@@ -309,9 +315,11 @@ func sendInviteEmail(ctx context.Context, apiKey, fromEmail, toEmail, password s
     <p style="margin: 0.25rem 0;"><strong>メールアドレス:</strong> %s</p>
     <p style="margin: 0.25rem 0;"><strong>パスワード:</strong> %s</p>
   </div>
+  <p style="margin: 1rem 0;"><a href="%s" style="display: inline-block; background: #df6900; color: #fff; text-decoration: none; padding: 0.75rem 1rem; border-radius: 8px;">ログイン画面を開く</a></p>
+  <p style="margin: 0.5rem 0; font-size: 0.875rem;">ボタンが開けない場合: <a href="%s">%s</a></p>
   <p style="color: #666; font-size: 0.875rem;">初回ログイン後、プロフィールの登録をお願いします。</p>
-</div>`, toEmail, password)
-	textBody := fmt.Sprintf("Backstage に招待されました。\n\nメールアドレス: %s\n初回パスワード: %s\n\n初回ログイン後、プロフィールの登録をお願いします。", toEmail, password)
+</div>`, toEmail, password, loginURL, loginURL, loginURL)
+	textBody := fmt.Sprintf("Backstage に招待されました。\n\nメールアドレス: %s\n初回パスワード: %s\nログイン画面: %s\n\n初回ログイン後、プロフィールの登録をお願いします。", toEmail, password, loginURL)
 
 	payload := map[string]interface{}{
 		"from":    fromEmail,

--- a/doc/10_frontend-auth-guide.md
+++ b/doc/10_frontend-auth-guide.md
@@ -127,7 +127,7 @@ async function fetchFromAPI(path: string) {
 
 - `/invite` ページからログイン済みメンバーが新規アカウントを発行できます
 - メールアドレスを入力すると API が Firebase Auth ユーザーを作成し、初回パスワードを自動生成します
-- Resend が設定されていれば、招待メールで初回ログイン情報を送信します
+- Resend が設定されていれば、招待メールで初回ログイン情報とログイン画面 URL（`INVITE_LOGIN_URL`）を送信します
 - 招待されたユーザーはログイン後に `/profile-setup` で初期プロフィールを登録します
 
 ### ロール付与


### PR DESCRIPTION
### Motivation
- 招待メールを受け取った新規ユーザーがすぐログインできるように、メール本文にログイン画面のURLを明示して案内するため。 

### Description
- 追加で `INVITE_LOGIN_URL` 環境変数を導入し、`api/internal/config/config.go` で読み込むようにしました。 
- HTTP ハンドラ初期化時に `cfg.InviteLoginURL` を `InviteDeps.LoginURL` として注入するように `api/internal/app/http.go` を更新しました。 
- `InviteDeps` に `LoginURL` を追加し、`sendInviteEmail` のシグネチャを変更して招待メールのHTML/テキスト本文にログイン画面URL（ボタンとリンク）を挿入するように `api/internal/simpleapi/invite.go` を更新しました。 
- ドキュメントに `INVITE_FROM_EMAIL` と `INVITE_LOGIN_URL` を追記し、フロントエンド認証ガイドに「招待メールでログイン画面URLを送信する」旨を反映しました（`api/README.md` と `doc/10_frontend-auth-guide.md`）。

### Testing
- 自動テストとして `cd api && go test ./internal/simpleapi ./internal/config ./internal/app` を実行し、いずれのパッケージもテストファイルは無く `go test` は正常終了しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c73db5c7b8832cb724ddb956359307)