### PR TITLE
fix(api): 招待メールの初回ログインURLをタイポドメインに統一

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -43,7 +43,7 @@ api/
 | `DEFAULT_ORG_SLUG` | seed 組織 slug |
 | `OWNER_EMAILS` | `OWNER` 扱いにする email の CSV |
 | `INVITE_FROM_EMAIL` | 招待メール送信元メールアドレス（デフォルト `no-reply@stepbycode.work`） |
-| `INVITE_LOGIN_URL` | 招待メールに記載するログイン画面 URL（デフォルト `https://backstage.stepbycode.work/login`） |
+| `INVITE_LOGIN_URL` | 招待メールに記載するログイン画面 URL（デフォルト `https://backatage.stepbycode.work/login`） |
 | `CORS_ALLOWED_ORIGINS` | 追加で許可する Origin の CSV。`https://backatage.stepbycode.work` のような完全一致と `https://*.stepbycode.work` / `*.vercel.app` のようなワイルドカードを受け付ける |
 | `PORT` | サーバーポート（デフォルト `9999`、Coolify では Internal Port も同じ値に揃える） |
 

--- a/api/internal/config/config.go
+++ b/api/internal/config/config.go
@@ -32,7 +32,7 @@ func Load() (Config, error) {
 		Port:                    defaultValue(strings.TrimSpace(os.Getenv("PORT")), "9999"),
 		ResendAPIKey:            strings.TrimSpace(os.Getenv("RESEND_API_KEY")),
 		InviteFromEmail:         defaultValue(strings.TrimSpace(os.Getenv("INVITE_FROM_EMAIL")), "no-reply@stepbycode.work"),
-		InviteLoginURL:          defaultValue(strings.TrimSpace(os.Getenv("INVITE_LOGIN_URL")), "https://backstage.stepbycode.work/login"),
+		InviteLoginURL:          defaultValue(strings.TrimSpace(os.Getenv("INVITE_LOGIN_URL")), "https://backatage.stepbycode.work/login"),
 		CronSecret:              strings.TrimSpace(os.Getenv("CRON_SECRET")),
 		CORSAllowedOrigins:      parseCSV(strings.TrimSpace(os.Getenv("CORS_ALLOWED_ORIGINS"))),
 	}

--- a/api/internal/simpleapi/invite.go
+++ b/api/internal/simpleapi/invite.go
@@ -303,7 +303,7 @@ func rollbackInvite(ctx context.Context, deps InviteDeps, uid string) error {
 func sendInviteEmail(ctx context.Context, apiKey, fromEmail, loginURL, toEmail, password string) error {
 	loginURL = strings.TrimSpace(loginURL)
 	if loginURL == "" {
-		loginURL = "https://backstage.stepbycode.work/login"
+		loginURL = "https://backatage.stepbycode.work/login"
 	}
 
 	htmlBody := fmt.Sprintf(`


### PR DESCRIPTION
### Motivation
- 発表対応のため、招待メールに含まれる初回ログインリンクを現行運用のタイポドメインに合わせる必要があったため。 

### Description
- `api/internal/config/config.go` の `INVITE_LOGIN_URL` デフォルト値を `https://backatage.stepbycode.work/login` に変更しました。 
- `api/internal/simpleapi/invite.go` 内の招待メール送信処理で使用するフォールバック URL を同じく `https://backatage.stepbycode.work/login` に変更しました。 
- `api/README.md` の `INVITE_LOGIN_URL` 環境変数説明のデフォルト値を更新しました。 

### Testing
- 自動テストとして `cd api && go test ./...` を実行し、テストは正常終了（テスト対象パッケージにはテストファイルがないパッケージが多く、`api/internal/corsutil` が `ok` でした）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7442f72e8832cb580072c2aa20d6e)