### PR TITLE
招待の自己取り消しを禁止

### DIFF
--- a/api/internal/simpleapi/invite.go
+++ b/api/internal/simpleapi/invite.go
@@ -231,7 +231,8 @@ func markInvitePasswordChangedHandler(client *db.Client) echo.HandlerFunc {
 
 func revokeInviteHandler(deps InviteDeps) echo.HandlerFunc {
 	return func(c echo.Context) error {
-		if _, ok := appctx.ActorFromContext(c.Request().Context()); !ok {
+		actor, ok := appctx.ActorFromContext(c.Request().Context())
+		if !ok {
 			return c.JSON(http.StatusUnauthorized, ErrorResponse{
 				Error: ErrorBody{Code: "UNAUTHORIZED", Message: "sign-in is required"},
 			})
@@ -240,6 +241,11 @@ func revokeInviteHandler(deps InviteDeps) echo.HandlerFunc {
 		uid := strings.TrimSpace(c.Param("uid"))
 		if uid == "" {
 			return validationError(c, "uid", "is required")
+		}
+		if actor.Subject == uid {
+			return c.JSON(http.StatusForbidden, ErrorResponse{
+				Error: ErrorBody{Code: "FORBIDDEN", Message: "cannot revoke your own invite"},
+			})
 		}
 
 		ctx := c.Request().Context()

--- a/doc/03_screen-flow.md
+++ b/doc/03_screen-flow.md
@@ -143,6 +143,7 @@ flowchart TD
 - `/profile-setup`
 - `/settings`
 - `/invite`
+  - 招待済みメンバー一覧では **自分自身の招待取り消しは不可**（UIでボタン無効化し、APIでも拒否）
 - `/`
 - `/meeting`
 - `/task-create`

--- a/doc/04_permission-design.md
+++ b/doc/04_permission-design.md
@@ -52,6 +52,9 @@
 | `PUT /api/v1/meetings/*` | 可 | 可 | 不可 | - |
 | `GET /api/v1/announcements/*` | 可 | 可 | 可 | - |
 | `PUT/POST /api/v1/announcements*` | 可 | 可 | 不可 | 投稿指示は API が正データ化 |
+| `GET /api/v1/invites` | 可 | 可 | 可 | 招待済み一覧の参照 |
+| `POST /api/v1/invite` | 可 | 可 | 不可 | 招待発行 |
+| `DELETE /api/v1/invite/{uid}` | 可 | 可 | 不可 | **自分自身 (`actor.subject == uid`) の取り消しは禁止** |
 | `GET/POST /internal/v1/announcement-publish-requests*` | service token | service token | service token | `X-Bot-Token` が必須 |
 
 ## 5. ABAC 条件

--- a/frontend/src/app/invite/page.tsx
+++ b/frontend/src/app/invite/page.tsx
@@ -83,6 +83,10 @@ export default function InvitePage() {
   };
 
   const handleRevoke = async (uid: string) => {
+    if (uid === user.uid) {
+      setError("自分自身の招待は取り消せません");
+      return;
+    }
     setError("");
     setRevokingUID(uid);
     try {
@@ -184,27 +188,46 @@ export default function InvitePage() {
             <p className="text-sm text-muted-foreground">まだ招待されたメンバーはいません。</p>
           ) : (
             <div className="space-y-2">
-              {invites.map((inv) => (
-                <div
-                  key={inv.uid}
-                  className="flex items-center justify-between rounded-xl border border-border/40 px-4 py-3"
-                >
-                  <div className="min-w-0">
-                    <p className="truncate text-sm">{inv.email}</p>
-                    <p className="text-xs text-muted-foreground">
-                      {inv.createdAt ? new Date(inv.createdAt).toLocaleDateString("ja-JP") : ""}
-                    </p>
-                  </div>
-                  <button
-                    type="button"
-                    onClick={() => handleRevoke(inv.uid)}
-                    disabled={revokingUID === inv.uid}
-                    className="rounded-full border border-red-200 px-3 py-1 text-xs font-semibold text-red-600 transition hover:bg-red-50 disabled:opacity-50"
+              {invites.map((inv) => {
+                // UI制御は補助目的。最終判定はAPI側で実施する。
+                // 自分自身の招待は取り消し操作を禁止する。
+                const isSelfInvite = inv.uid === user.uid;
+
+                return (
+                  <div
+                    key={inv.uid}
+                    className="flex items-center justify-between rounded-xl border border-border/40 px-4 py-3"
                   >
-                    {revokingUID === inv.uid ? "取消中..." : "取り消す"}
-                  </button>
-                </div>
-              ))}
+                    <div className="min-w-0">
+                      <p className="truncate text-sm">
+                        {inv.email}
+                        {isSelfInvite && (
+                          <span className="ml-2 text-xs text-muted-foreground">(自分)</span>
+                        )}
+                      </p>
+                      <p className="text-xs text-muted-foreground">
+                        {inv.createdAt ? new Date(inv.createdAt).toLocaleDateString("ja-JP") : ""}
+                      </p>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => handleRevoke(inv.uid)}
+                      disabled={revokingUID === inv.uid || isSelfInvite}
+                      className={`rounded-full border px-3 py-1 text-xs font-semibold transition disabled:opacity-50 ${
+                        isSelfInvite
+                          ? "border-border/60 text-muted-foreground"
+                          : "border-red-200 text-red-600 hover:bg-red-50"
+                      }`}
+                    >
+                      {revokingUID === inv.uid
+                        ? "取消中..."
+                        : isSelfInvite
+                          ? "自分は取消不可"
+                          : "取り消す"}
+                    </button>
+                  </div>
+                );
+              })}
             </div>
           )}
         </div>


### PR DESCRIPTION
### Motivation
- 招待済みメンバー一覧でユーザーが自分の招待を誤って取り消したり、UIを迂回して自己取り消しAPIを叩けないようにするためのセーフガードを追加します。

### Description
- サーバー側で `DELETE /api/v1/invite/{uid}` を受けたときに、認可情報の `actor.subject == uid` をチェックして自己取り消しを `403 FORBIDDEN` として拒否するようにしました (`api/internal/simpleapi/invite.go`).
- フロントエンドの招待画面で自己招待の行に `(自分)` ラベルを表示し、取り消しボタンを無効化して文言を変更することでUI側でも誤操作を防止するロジックを追加しました (`frontend/src/app/invite/page.tsx`).
- ドキュメントに挙動を明記しました: 画面フローに注意書きを追加し、権限設計に `DELETE /api/v1/invite/{uid}` の自己取り消し禁止ルールを追記しました (`doc/03_screen-flow.md`, `doc/04_permission-design.md`).

### Testing
- `cd api && go test ./...` を実行しテストは完了しました（パッケージにテストファイルが無い箇所が多く、実行は成功しました）。
- `cd frontend && npm run build` を実行しフロントエンドのビルドは成功して静的ページが生成されました。 
- `cd frontend && npm run lint` は `package.json` に `lint` スクリプトが定義されていないため実行できませんでした（未定義のため失敗）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c744c521f0832cba669f28cd0434f6)