### PR TITLE
fix: タスク作成の保存先を選択中の年月に固定

### DIFF
--- a/api/internal/simpleapi/task.go
+++ b/api/internal/simpleapi/task.go
@@ -295,6 +295,12 @@ func createTaskHandler(client *db.Client) echo.HandlerFunc {
 		if req.AssigneeID == "" && !taskAllowsEmptyAssignee(title) {
 			return validationError(c, "assigneeId", "is required")
 		}
+		if req.Year < 2000 || req.Year > 2100 {
+			return validationError(c, "year", "must be between 2000 and 2100")
+		}
+		if req.Month < 1 || req.Month > 12 {
+			return validationError(c, "month", "must be between 1 and 12")
+		}
 
 		collection := tasksCollectionForPeriod(req.Year, req.Month)
 		id := "task-" + uuid.New().String()[:8]

--- a/frontend/src/components/task-board.tsx
+++ b/frontend/src/components/task-board.tsx
@@ -220,6 +220,11 @@ export function TaskBoard() {
     if (!newTitle.trim() || !newAssigneeId) return;
     setCreateError("");
 
+    const targetPeriod = {
+      year: selectedPeriod.year,
+      month: selectedPeriod.month,
+    };
+
     try {
       const token = await getIdToken();
       const res = await apiFetch("/api/v1/tasks", token, {
@@ -227,8 +232,8 @@ export function TaskBoard() {
         body: JSON.stringify({
           title: newTitle.trim(),
           assigneeId: newAssigneeId,
-          year: selectedPeriod.year,
-          month: selectedPeriod.month,
+          year: targetPeriod.year,
+          month: targetPeriod.month,
         }),
       });
       if (res.ok) {
@@ -249,9 +254,9 @@ export function TaskBoard() {
         setNewTitle("");
         setNewAssigneeId("");
         setCreateOpen(false);
-        void fetchTasks(selectedPeriod.year, selectedPeriod.month, { silent: true });
+        void fetchTasks(targetPeriod.year, targetPeriod.month, { silent: true });
       } else {
-        let message = `${periodLabel(selectedPeriod)} へのタスク保存に失敗しました。`;
+        let message = `${periodLabel(targetPeriod)} へのタスク保存に失敗しました。`;
         try {
           const errorData = await res.json();
           if (typeof errorData?.message === "string" && errorData.message.trim()) {
@@ -263,7 +268,7 @@ export function TaskBoard() {
         setCreateError(message);
       }
     } catch {
-      setCreateError(`${periodLabel(selectedPeriod)} へのタスク保存中に通信エラーが発生しました。`);
+      setCreateError(`${periodLabel(targetPeriod)} へのタスク保存中に通信エラーが発生しました。`);
     }
   };
 


### PR DESCRIPTION
### Motivation
- タスクを追加した際に、月を切り替えている最中だと意図せず当月(またはデフォルトコレクション)に保存される不具合を修正するための変更です。

### Description
- フロントエンドでタスク作成時に `selectedPeriod` をその場でスナップショットして `targetPeriod` とし、API への送信・再取得・エラーメッセージ表示に一貫してその期間を使うようにしました（`frontend/src/components/task-board.tsx`）。
- API 側のタスク作成処理に `year`/`month` の範囲バリデーションを追加し、無効な値でデフォルトコレクションへ保存される事態を防止しました（`api/internal/simpleapi/task.go`）。
- 変更対象ファイルは `frontend/src/components/task-board.tsx` と `api/internal/simpleapi/task.go` です。

### Testing
- 自動テストとして `cd api && go test ./...` を実行して全パッケージが問題なく終了しました（成功）。
- フロントエンドのビルドとして `cd frontend && npm run build` を実行し、ビルドは成功しました（成功）。
- `cd frontend && npm run lint` はプロジェクトの `package.json` に `lint` スクリプトが定義されていないため実行できませんでした（未実施）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c74ffef3a0832c8bb803357c46b76a)